### PR TITLE
Enable playing of RTSP/RTMP streams

### DIFF
--- a/piomxtextures_src/piomxtextures_src.pri
+++ b/piomxtextures_src/piomxtextures_src.pri
@@ -58,7 +58,7 @@ LIBS += $$PWD/../3rdparty/ffmpeg/$$FFMPEG_BUILD_DIR/lib/libavformat.a \
 	$$PWD/../3rdparty/ffmpeg/$$FFMPEG_BUILD_DIR/lib/libavutil.a \
 	$$PWD/../3rdparty/ffmpeg/$$FFMPEG_BUILD_DIR/lib/libswscale.a \
 	$$PWD/../3rdparty/ffmpeg/$$FFMPEG_BUILD_DIR/lib/libswresample.a \
-   -lz -lssl -lcrypto -lsmbclient -lssh -lbz2 -lpcre
+   -lz -lssl -lcrypto -lsmbclient -lssh -lbz2 -lpcre -lrtmp
 }
 else {
 LIBS += -L$$PWD/../3rdparty/ffmpeg/$$FFMPEG_BUILD_DIR/lib \

--- a/piomxtextures_tools/compile_ffmpeg.sh
+++ b/piomxtextures_tools/compile_ffmpeg.sh
@@ -514,6 +514,8 @@ else
 --disable-decoder=idf \
 --disable-decoder=hevc \
 --enable-decoder=opus \
+--enable-librtmp \
+--enable-libx264 \
 --disable-decoder=vc1 --disable-demuxer=vc1 --disable-muxer=vc1 --disable-parser=vc1 \
 --cross-prefix=arm-linux-gnueabihf- \
 --prefix=$PWD/ffmpeg_compiled \


### PR DESCRIPTION
While it is possible to play http streams with your setup, there are some changes required to play streams from video cameras. At least it is required to have libx264 and librtmp libraries enabled at FFmpeg configure.