### PR TITLE
Added support for building with qt built for rpi 3

### DIFF
--- a/piomxtextures_src/piomxtextures_src.pri
+++ b/piomxtextures_src/piomxtextures_src.pri
@@ -49,6 +49,11 @@ linux-rasp-pi2-g++ {
 	FFMPEG_BUILD_DIR = ffmpeg_pi2
 }
 
+linux-rpi3-g++|linux-rasp-pi3-g++ {
+	message("Building for RPi3...");
+	FFMPEG_BUILD_DIR = ffmpeg_pi2
+}
+
 LIBS += -lopenmaxil -lGLESv2 -lEGL -lbcm_host -lvchostif -lvcos -lrt -lv4l2
 INCLUDEPATH += $$PWD/../3rdparty/ffmpeg/$$FFMPEG_BUILD_DIR/include
 #LIBS += -lavformat -lavcodec -lavutil


### PR DESCRIPTION
This change enables building piomxtextures against QT built with rpi3 spec. Uses ffmpeg built with `pi2`.

`linux-rpi3-g++` is for qt 5.6, 5.7, 5.8

`linux-rasp-pi3-g++` is for qt 5.9+